### PR TITLE
Use `he` for robust HTML entity encoding/decoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "mime": "~1.2.9",
-    "ent": "~0.1.0",
-    "easyreq": "~0.1.0"
+    "easyreq": "~0.1.0",
+    "he": "~0.4.1"
   }
 }

--- a/static-route.js
+++ b/static-route.js
@@ -6,7 +6,7 @@ var path = require('path');
 var url = require('url');
 var util = require('util');
 
-var ent = require('ent');
+var he = require('he');
 var mime = require('mime');
 var easyreq = require('easyreq');
 
@@ -206,7 +206,7 @@ function statall(dir, cb) {
 // given a `res` object, base dir, and files array, write HTML
 // to the receiving end
 function writehtml(res, base, files) {
-  var title = ent.encode(util.format('Index of %s', base));
+  var title = he.encode(util.format('Index of %s', base));
   res.write('<!doctype html><html><head><title>\n');
   res.write(title);
   res.write('\n</title></head><body>\n');
@@ -217,7 +217,7 @@ function writehtml(res, base, files) {
     var linktext = file;
     var linkhref = path.join(base, file);
     res.write(util.format('<li><a href="%s">%s</a></li>\n',
-        ent.encode(linkhref), ent.encode(linktext)));
+        he.encode(linkhref), he.encode(linktext)));
   });
   res.write('</ul>\n');
   res.write('<hr />\n');


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](http://mths.be/he).
